### PR TITLE
Added RGB and RGBA Support + Prefix logic + CPrintToServer

### DIFF
--- a/addons/sourcemod/scripting/include/multicolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors.inc
@@ -27,7 +27,19 @@
 /* Global var to check whether colors are fixed or not */
 bool g_bCFixColors = false;
 
+#define PREFIX_MAX_LENGTH 64
+char g_sPrefix[PREFIX_MAX_LENGTH] = "";
 
+/**
+ * Add a chat prefix before all chat msg
+ *
+ * @param sPrefix		Prefix
+ */
+stock void CSetPrefix(const char[] sPrefix, any ...) {
+	VFormat(g_sPrefix, sizeof(g_sPrefix) - 10, sPrefix, 2);
+	// Add ending space
+	Format(g_sPrefix, sizeof(g_sPrefix), "%s{default} ", g_sPrefix);
+}
 
 /**
  * Writes a message to a client with the correct stock for the game.
@@ -35,7 +47,6 @@ bool g_bCFixColors = false;
  * @param client        Client index.
  * @param message       Message (formatting rules).
  *
- * @noreturn
  * @error               If the client is not connected an error will be thrown.
  */
 stock void CPrintToChat(int client, const char[] message, any ...)
@@ -47,9 +58,9 @@ stock void CPrintToChat(int client, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_PrintToChat(client, "%s", buffer);
+		C_PrintToChat(client, "%s%s", g_sPrefix, buffer);
 	else
-		MC_PrintToChat(client, "%s", buffer);
+		MC_PrintToChat(client, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -60,7 +71,6 @@ stock void CPrintToChat(int client, const char[] message, any ...)
  *
  * @param client	  Client index.
  * @param message     Message (formatting rules)
- * @return			  No return
  */
 stock void CPrintToChatAll(const char[] message, any ...)
 {
@@ -71,9 +81,9 @@ stock void CPrintToChatAll(const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_PrintToChatAll("%s", buffer);
+		C_PrintToChatAll("%s%s", g_sPrefix, buffer);
 	else
-		MC_PrintToChatAll("%s", buffer);
+		MC_PrintToChatAll("%s%s", g_sPrefix, buffer);
 }
 
 /**
@@ -81,8 +91,6 @@ stock void CPrintToChatAll(const char[] message, any ...)
  *
  * @param target 	Client index.
  * @param message	Message (formatting rules).
- *
- * @noreturn
  */
 stock void CPrintToChatObservers(int target, const char[] message, any ...)
 {
@@ -91,7 +99,7 @@ stock void CPrintToChatObservers(int target, const char[] message, any ...)
 
 	if (!g_bCFixColors)
 		CFixColors();
-	
+
  	for(int client = 1; client <= MaxClients; client++)
 	{
  		if(IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client))
@@ -115,7 +123,6 @@ stock void CPrintToChatObservers(int target, const char[] message, any ...)
  * @param author        Author index.
  * @param message       Message (formatting rules).
  *
- * @noreturn
  * @error               If the client is not connected an error will be thrown.
  */
 stock void CPrintToChatEx(int client, int author, const char[] message, any ...)
@@ -125,11 +132,11 @@ stock void CPrintToChatEx(int client, int author, const char[] message, any ...)
 
 	if (!g_bCFixColors)
 		CFixColors();
-	
+
 	if (!IsSource2009())
-		C_PrintToChatEx(client, author, "%s", buffer);
+		C_PrintToChatEx(client, author, "%s%s", g_sPrefix, buffer);
 	else
-		MC_PrintToChatEx(client, author, "%s", buffer);
+		MC_PrintToChatEx(client, author, "%s%s", g_sPrefix, buffer);
 }
 
 /**
@@ -137,8 +144,6 @@ stock void CPrintToChatEx(int client, int author, const char[] message, any ...)
  *
  * @param author        Author index.
  * @param message       Message (formatting rules).
- *
- * @noreturn
  */
 stock void CPrintToChatAllEx(int author, const char[] message, any ...)
 {
@@ -149,9 +154,9 @@ stock void CPrintToChatAllEx(int author, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_PrintToChatAllEx(author, "%s", buffer);
+		C_PrintToChatAllEx(author, "%s%s", g_sPrefix, buffer);
 	else
-		MC_PrintToChatAllEx(author, "%s", buffer);
+		MC_PrintToChatAllEx(author, "%s%s", g_sPrefix, buffer);
 }
 
 /**
@@ -160,8 +165,6 @@ stock void CPrintToChatAllEx(int author, const char[] message, any ...)
  *
  * @param target 	Client index.
  * @param message	Message (formatting rules).
- *
- * @noreturn
  */
 stock void CPrintToChatObserversEx(int target, const char[] message, any ...)
 {
@@ -170,7 +173,7 @@ stock void CPrintToChatObserversEx(int target, const char[] message, any ...)
 
 	if (!g_bCFixColors)
 		CFixColors();
-	
+
  	for(int client = 1; client <= MaxClients; client++)
 	{
  		if(IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client))
@@ -192,7 +195,6 @@ stock void CPrintToChatObserversEx(int target, const char[] message, any ...)
  * 
  * @param client		Client to reply to
  * @param message		Message (formatting rules)
- * @noreturn
  */
 stock void CReplyToCommand(int author, const char[] message, any ...)
 {
@@ -203,9 +205,9 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ReplyToCommand(author, "%s", buffer);
+		C_ReplyToCommand(author, "%s%s", g_sPrefix, buffer);
 	else
-		MC_ReplyToCommand(author, "%s", buffer);
+		MC_ReplyToCommand(author, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -216,7 +218,6 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
  * @param client		Client to reply to
  * @param author		Client to use for {teamcolor}
  * @param message		Message (formatting rules)
- * @noreturn
  */
  stock void CReplyToCommandEx(int client, int author, const char[] message, any ...)
 {
@@ -228,9 +229,9 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ReplyToCommandEx(client, author, "%s", buffer);
+		C_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
 	else
-		MC_ReplyToCommandEx(client, author, "%s", buffer);
+		MC_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -248,7 +249,7 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
  * @param client		Client index doing the action, or 0 for server.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
+ * 
  * @error
  */
 stock void CShowActivity(int author, const char[] message, any ...)
@@ -260,9 +261,9 @@ stock void CShowActivity(int author, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivity(author, "%s", buffer);
+		C_ShowActivity(author, "%s%s", g_sPrefix, buffer);
 	else
-		MC_ShowActivity(author, "%s", buffer);
+		MC_ShowActivity(author, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -274,7 +275,7 @@ stock void CShowActivity(int author, const char[] message, any ...)
  * @param tags			Tag to display with.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
+ * 
  * @error
  */
 stock void CShowActivityEx(int author, const char[] tag, const char[] message, any ...)
@@ -286,9 +287,9 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivityEx(author, tag, "%s", buffer);
+		C_ShowActivityEx(author, tag, "%s%s", g_sPrefix, buffer);
 	else
-		MC_ShowActivityEx(author, tag, "%s", buffer);
+		MC_ShowActivityEx(author, tag, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -303,7 +304,7 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
  * @param tags			Tag to prepend to the message.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
+ * 
  * @error
  */
  stock void CShowActivity2(int author, const char[] tag, const char[] message, any ...)
@@ -315,9 +316,9 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivity2(author, tag, "%s", buffer);
+		C_ShowActivity2(author, tag, "%s%s", g_sPrefix, buffer);
 	else
-		MC_ShowActivity2(author, tag, "%s", buffer);
+		MC_ShowActivity2(author, tag, "%s%s", g_sPrefix, buffer);
 }
 
 
@@ -327,8 +328,6 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
  *
  * @param message       String.
  * @param maxlength     Maximum length of the string buffer.
- *
- * @noreturn
  */
 stock void CFormatColor(char[] message, int maxlength, int author = -1)
 {
@@ -339,7 +338,7 @@ stock void CFormatColor(char[] message, int maxlength, int author = -1)
 	{
 		if (author == 0)
 			author = -1;
-	
+
 		C_Format(message, maxlength, author);
 	}
 	else
@@ -358,7 +357,6 @@ stock void CFormatColor(char[] message, int maxlength, int author = -1)
  * 
  * @param message		Message to remove tags from
  * @param maxlen		Maximum buffer length
- * @noreturn
  */
 stock void CRemoveTags(char[] message, int maxlen)
 {
@@ -376,8 +374,6 @@ stock void CRemoveTags(char[] message, int maxlen)
 
 /**
  * Fixes missing Lightgreen color.
- *
- * @noreturn
  */
 stock void CFixColors()
 {

--- a/addons/sourcemod/scripting/include/multicolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors.inc
@@ -28,6 +28,8 @@
 bool g_bCFixColors = false;
 
 #define PREFIX_MAX_LENGTH 64
+#define PREFIX_SEPARATOR "{default} "
+
 char g_sPrefix[PREFIX_MAX_LENGTH] = "";
 
 /**
@@ -36,9 +38,22 @@ char g_sPrefix[PREFIX_MAX_LENGTH] = "";
  * @param sPrefix		Prefix
  */
 stock void CSetPrefix(const char[] sPrefix, any ...) {
-	VFormat(g_sPrefix, sizeof(g_sPrefix) - 10, sPrefix, 2);
+	if (!sPrefix[0])
+		return;
+
+	VFormat(g_sPrefix, sizeof(g_sPrefix) - strlen(PREFIX_SEPARATOR), sPrefix, 2);
+
 	// Add ending space
-	Format(g_sPrefix, sizeof(g_sPrefix), "%s{default} ", g_sPrefix);
+	Format(g_sPrefix, sizeof(g_sPrefix), "%s%s", g_sPrefix, PREFIX_SEPARATOR);
+}
+
+/**
+ * Add a chat prefix before all chat msg
+ *
+ * @param sPrefix		Prefix
+ */
+stock void CClearPrefix() {
+	g_sPrefix[0] = '\0';
 }
 
 /**
@@ -237,8 +252,6 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
 /**
  * Remove all tags and print to server
  * 
- * @param client		Client to reply to
- * @param author		Client to use for {teamcolor}
  * @param message		Message (formatting rules)
  */
  stock void CPrintToServer(const char[] message, any ...)
@@ -246,7 +259,7 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
 	char buffer[MAX_MESSAGE_LENGTH];
 	char prefixBuffer[PREFIX_MAX_LENGTH];
 
-	VFormat(buffer, sizeof(buffer), message, 4);
+	VFormat(buffer, sizeof(buffer), message, 2);
 	strcopy(prefixBuffer, sizeof(prefixBuffer), g_sPrefix);
 
 	if (!g_bCFixColors)
@@ -285,9 +298,9 @@ stock void CShowActivity(int author, const char[] message, any ...)
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivity(author, "%s%s", g_sPrefix, buffer);
+		C_ShowActivity(author, "%s", buffer);
 	else
-		MC_ShowActivity(author, "%s%s", g_sPrefix, buffer);
+		MC_ShowActivity(author, "%s", buffer);
 }
 
 
@@ -311,9 +324,9 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivityEx(author, tag, "%s%s", g_sPrefix, buffer);
+		C_ShowActivityEx(author, tag, "%s", buffer);
 	else
-		MC_ShowActivityEx(author, tag, "%s%s", g_sPrefix, buffer);
+		MC_ShowActivityEx(author, tag, "%s", buffer);
 }
 
 
@@ -340,9 +353,9 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
 		CFixColors();
 
 	if (!IsSource2009())
-		C_ShowActivity2(author, tag, "%s%s", g_sPrefix, buffer);
+		C_ShowActivity2(author, tag, "%s", buffer);
 	else
-		MC_ShowActivity2(author, tag, "%s%s", g_sPrefix, buffer);
+		MC_ShowActivity2(author, tag, "%s", buffer);
 }
 
 

--- a/addons/sourcemod/scripting/include/multicolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors.inc
@@ -1,9 +1,9 @@
-#if defined _mutlicolors_included
+#if defined _multicolors_included
 	#endinput
 #endif
-#define _mutlicolors_included
+#define _multicolors_included
 
-#define MuCo_VERSION "2.0.1"
+#define MuCo_VERSION "2.1.0"
 #define MuCo_LoopClients(%1) for(int %1 = 1; %1 <= MaxClients; %1++)
 
 #include <multicolors/morecolors>
@@ -232,6 +232,30 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
 		C_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
 	else
 		MC_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
+}
+
+/**
+ * Remove all tags and print to server
+ * 
+ * @param client		Client to reply to
+ * @param author		Client to use for {teamcolor}
+ * @param message		Message (formatting rules)
+ */
+ stock void CPrintToServer(const char[] message, any ...)
+{
+	char buffer[MAX_MESSAGE_LENGTH];
+	char prefixBuffer[PREFIX_MAX_LENGTH];
+
+	VFormat(buffer, sizeof(buffer), message, 4);
+	strcopy(prefixBuffer, sizeof(prefixBuffer), g_sPrefix);
+
+	if (!g_bCFixColors)
+		CFixColors();
+
+	CRemoveTags(buffer, sizeof(buffer));
+	CRemoveTags(prefixBuffer, sizeof(prefixBuffer));
+
+	PrintToServer("%s%s", prefixBuffer, buffer);
 }
 
 

--- a/addons/sourcemod/scripting/include/multicolors/colors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/colors.inc
@@ -69,20 +69,20 @@ stock void C_PrintToChat(int client, const char[] szMessage, any ...)
 {
 	if (client <= 0 || client > MaxClients)
 		ThrowError("Invalid client index %d", client);
-	
+
 	if (!IsClientInGame(client))
 		ThrowError("Client %d is not in game", client);
-	
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	char szCMessage[MAX_MESSAGE_LENGTH];
 
 	SetGlobalTransTarget(client);
-	
+
 	Format(szBuffer, sizeof(szBuffer), "\x01%s", szMessage);
 	VFormat(szCMessage, sizeof(szCMessage), szBuffer, 3);
-	
+
 	int index = C_Format(szCMessage, sizeof(szCMessage));
-	
+
 	if (index == NO_INDEX)
 		PrintToChat(client, "%s", szCMessage);
 	else
@@ -106,7 +106,7 @@ stock void C_ReplyToCommand(int client, const char[] szMessage, any ...)
 	char szCMessage[MAX_MESSAGE_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(szCMessage, sizeof(szCMessage), szMessage, 3);
-	
+
 	if (client == 0)
 	{
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
@@ -141,7 +141,7 @@ stock void C_ReplyToCommandEx(int client, int author, const char[] szMessage, an
 	char szCMessage[MAX_MESSAGE_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(szCMessage, sizeof(szCMessage), szMessage, 4);
-	
+
 	if (client == 0)
 	{
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
@@ -169,17 +169,17 @@ stock void C_ReplyToCommandEx(int client, int author, const char[] szMessage, an
 stock void C_PrintToChatAll(const char[] szMessage, any ...)
 {
 	char szBuffer[MAX_MESSAGE_LENGTH];
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i > 0 && IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i])
 		{
 			SetGlobalTransTarget(i);
 			VFormat(szBuffer, sizeof(szBuffer), szMessage, 2);
-			
+
 			C_PrintToChat(i, "%s", szBuffer);
 		}
-		
+
 		C_SkipList[i] = false;
 	}
 }
@@ -199,23 +199,23 @@ stock void C_PrintToChatEx(int client, int author, const char[] szMessage, any .
 {
 	if (client <= 0 || client > MaxClients)
 		ThrowError("Invalid client index %d", client);
-	
+
 	if (!IsClientInGame(client))
 		ThrowError("Client %d is not in game", client);
-	
+
 	if (author < 0 || author > MaxClients)
 		ThrowError("Invalid client index %d", author);
-	
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	char szCMessage[MAX_MESSAGE_LENGTH];
 
 	SetGlobalTransTarget(client);
-	
+
 	Format(szBuffer, sizeof(szBuffer), "\x01%s", szMessage);
 	VFormat(szCMessage, sizeof(szCMessage), szBuffer, 4);
-	
+
 	int index = C_Format(szCMessage, sizeof(szCMessage), author);
-	
+
 	if (index == NO_INDEX)
 		PrintToChat(client, "%s", szCMessage);
 	else
@@ -236,22 +236,22 @@ stock void C_PrintToChatAllEx(int author, const char[] szMessage, any ...)
 {
 	if (author < 0 || author > MaxClients)
 		ThrowError("Invalid client index %d", author);
-	
+
 	if (!IsClientInGame(author))
 		ThrowError("Client %d is not in game", author);
-	
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i > 0 && IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i])
 		{
 			SetGlobalTransTarget(i);
 			VFormat(szBuffer, sizeof(szBuffer), szMessage, 3);
-			
+
 			C_PrintToChatEx(i, author, "%s", szBuffer);
 		}
-		
+
 		C_SkipList[i] = false;
 	}
 }
@@ -266,7 +266,7 @@ stock void C_RemoveTags(char[] szMessage, int maxlength)
 {
 	for (int i = 0; i < MAX_COLORS; i++)
 		ReplaceString(szMessage, maxlength, C_Tag[i], "", false);
-	
+
 	ReplaceString(szMessage, maxlength, "{teamcolor}", "", false);
 }
 
@@ -281,10 +281,10 @@ stock bool C_ColorAllowed(C_Colors color)
 	if (!C_EventIsHooked)
 	{
 		C_SetupProfile();
-		
+
 		C_EventIsHooked = true;
 	}
-	
+
 	return C_Profile_Colors[color];
 }
 
@@ -301,13 +301,13 @@ stock void C_ReplaceColor(C_Colors color, C_Colors newColor)
 	if (!C_EventIsHooked)
 	{
 		C_SetupProfile();
-		
+
 		C_EventIsHooked = true;
 	}
-	
+
 	C_Profile_Colors[color] = C_Profile_Colors[newColor];
 	C_Profile_TeamIndex[color] = C_Profile_TeamIndex[newColor];
-	
+
 	C_TagReqSayText2[color] = C_TagReqSayText2[newColor];
 	Format(C_TagCode[color], sizeof(C_TagCode[]), C_TagCode[newColor]);
 }
@@ -326,7 +326,7 @@ stock void C_SkipNextClient(int client)
 {
 	if (client <= 0 || client > MaxClients)
 		ThrowError("Invalid client index %d", client);
-	
+
 	C_SkipList[client] = true;
 }
 
@@ -346,25 +346,25 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 	{
 		C_SetupProfile();
 		HookEvent("server_spawn", C_Event_MapStart, EventHookMode_PostNoCopy);
-		
+
 		C_EventIsHooked = true;
 	}
-	
+
 	int iRandomPlayer = NO_INDEX;
-	
+
 	// On CS:GO set invisible precolor
 	if (GetEngineVersion() == Engine_CSGO) 
 	{
 		Format(szMessage, maxlength, " %s", szMessage);
 	}
-	
+
 	/* If author was specified replace {teamcolor} tag */
 	if (author != NO_INDEX)
 	{
 		if (C_Profile_SayText2)
 		{
 			ReplaceString(szMessage, maxlength, "{teamcolor}", "\x03", false);
-			
+
 			iRandomPlayer = author;
 		}
 		/* If saytext2 is not supported by game replace {teamcolor} with green tag  */
@@ -373,18 +373,18 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 	}
 	else
 		ReplaceString(szMessage, maxlength, "{teamcolor}", "", false);
-	
+
 	/* For other color tags we need a loop */
 	for (int i = 0; i < MAX_COLORS; i++)
 	{
 		/* If tag not found - skip */
 		if (StrContains(szMessage, C_Tag[i], false) == -1)
 			continue;
-			
+
 		/* If tag is not supported by game replace it with green tag */
 		else if (!C_Profile_Colors[i])
 			ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
-		
+
 		/* If tag doesn't need saytext2 simply replace */
 		else if (!C_TagReqSayText2[i])
 			ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[i], false);
@@ -395,7 +395,7 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 			/* If saytext2 is not supported by game replace tag with green tag */
 			if (!C_Profile_SayText2)
 				ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
-				
+
 			/* Game supports saytext2 */
 			else 
 			{
@@ -404,7 +404,7 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 				{
 					/* Searching for valid client for tag */
 					iRandomPlayer = C_FindRandomPlayerByTeam(C_Profile_TeamIndex[i]);
-					
+
 					/* If player not found replace tag with green color tag */
 					if (iRandomPlayer == NO_PLAYER)
 						ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
@@ -412,7 +412,7 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 					/* If player was found simply replace */
 					else
 						ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[i], false);
-					
+
 				}
 				/* If found another team color tag throw error */
 				else
@@ -421,10 +421,10 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 					ThrowError("Using two team colors in one message is not allowed");
 				}
 			}
-			
+
 		}
 	}
-	
+
 	return iRandomPlayer;
 }
 
@@ -444,7 +444,7 @@ stock int C_FindRandomPlayerByTeam(int color_team)
 		{
 			if (i > 0 && IsClientInGame(i) && GetClientTeam(i) == color_team)
 				return i;
-		}	
+		}
 	}
 
 	return NO_PLAYER;
@@ -461,7 +461,7 @@ stock int C_FindRandomPlayerByTeam(int color_team)
 stock void C_SayText2(int client, int author, const char[] szMessage)
 {
 	Handle hBuffer = StartMessageOne("SayText2", client, USERMSG_RELIABLE|USERMSG_BLOCKHOOKS);
-	
+
 	if(GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) 
 	{
 		PbSetInt(hBuffer, "ent_idx", author);
@@ -478,7 +478,7 @@ stock void C_SayText2(int client, int author, const char[] szMessage)
 		BfWriteByte(hBuffer, true);
 		BfWriteString(hBuffer, szMessage);
 	}
-	
+
 	EndMessage();
 }
 
@@ -491,7 +491,7 @@ stock void C_SayText2(int client, int author, const char[] szMessage)
 stock void C_SetupProfile()
 {
 	EngineVersion engine = GetEngineVersion();
-	
+
 	if (engine == Engine_CSS)
 	{
 		C_Profile_Colors[Color_Lightgreen] = true;
@@ -540,7 +540,7 @@ stock void C_SetupProfile()
 		C_Profile_Colors[Color_Lightgreen] = true;
 		C_Profile_Colors[Color_Red] = true;
 		C_Profile_Colors[Color_Blue] = true;
-		C_Profile_Colors[Color_Olive] = true;		
+		C_Profile_Colors[Color_Olive] = true;
 		C_Profile_TeamIndex[Color_Lightgreen] = SERVER_INDEX;
 		C_Profile_TeamIndex[Color_Red] = 3;
 		C_Profile_TeamIndex[Color_Blue] = 2;
@@ -590,7 +590,7 @@ stock void C_SetupProfile()
 public Action C_Event_MapStart(Event event, const char[] name, bool dontBroadcast)
 {
 	C_SetupProfile();
-	
+
 	MuCo_LoopClients(i)
 		C_SkipList[i] = false;
 }
@@ -615,14 +615,14 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 {
 	if (sm_show_activity == null)
 		sm_show_activity = FindConVar("sm_show_activity");
-		
+
 	char tag[] = "[SM] ";
-	
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
 	int  value = GetConVarInt(sm_show_activity);
 	ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
@@ -630,7 +630,7 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -638,13 +638,13 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 		{
 			sign = "PLAYER";
 		}
-		
+
 		/* Display the message to the client? */
 		if (replyto == SM_REPLY_TO_CONSOLE)
 		{
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 3);
-			
+
 			C_RemoveTags(szBuffer, sizeof(szBuffer));
 			PrintToConsole(client, "%s%s\n", tag, szBuffer);
 			display_in_chat = true;
@@ -654,16 +654,16 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 3);
-		
+
 		C_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -688,7 +688,7 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -707,12 +707,12 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -731,12 +731,12 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 {
 	if (sm_show_activity == null)
 		sm_show_activity = FindConVar("sm_show_activity");
-		
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
 	int value = GetConVarInt(sm_show_activity);
 	ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
@@ -744,7 +744,7 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -752,13 +752,13 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 		{
 			sign = "PLAYER";
 		}
-		
+
 		/* Display the message to the client? */
 		if (replyto == SM_REPLY_TO_CONSOLE)
 		{
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 4);
-			
+
 			C_RemoveTags(szBuffer, sizeof(szBuffer));
 			PrintToConsole(client, "%s%s\n", tag, szBuffer);
 			display_in_chat = true;
@@ -768,16 +768,16 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		C_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -802,7 +802,7 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -821,12 +821,12 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -847,19 +847,19 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 {
 	if (sm_show_activity == null)
 		sm_show_activity = FindConVar("sm_show_activity");
-	
+
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
 	int value = GetConVarInt(sm_show_activity);
 	// ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	if (client != 0)
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -867,30 +867,30 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 		{
 			sign = "PLAYER";
 		}
-		
+
 		SetGlobalTransTarget(client);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		/* We don't display directly to the console because the chat text 
 		 * simply gets added to the console, so we don't want it to print 
 		 * twice.
-		 */		
+		 */
 		C_PrintToChatEx(client, client, "%s%s", tag, szBuffer);
 	}
 	else
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		C_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -915,7 +915,7 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -934,11 +934,11 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
-	return 1;	
+
+	return 1;
 }

--- a/addons/sourcemod/scripting/include/multicolors/morecolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/morecolors.inc
@@ -32,7 +32,6 @@ static Handle sm_show_activity = INVALID_HANDLE;
  * 
  * @param client		Client index.
  * @param message		Message (formatting rules).
- * @noreturn
  * 
  * On error/Errors:		If the client is not connected an error will be thrown.
  */
@@ -58,7 +57,6 @@ stock void MC_PrintToChat(int client, const char[] message, any ...) {
  * 
  * @param client		Client index.
  * @param message		Message (formatting rules).
- * @noreturn
  */
 stock void MC_PrintToChatAll(const char[] message, any ...) {
 	MC_CheckTrie();
@@ -83,7 +81,6 @@ stock void MC_PrintToChatAll(const char[] message, any ...) {
  * @param client		Client index.
  * @param author		Author index whose color will be used for teamcolor tag.
  * @param message		Message (formatting rules).
- * @noreturn
  * 
  * On error/Errors:		If the client or author are not connected an error will be thrown
  */
@@ -115,7 +112,6 @@ stock void MC_PrintToChatEx(int client, int author, const char[] message, any ..
  *
  * @param author	  Author index whose color will be used for teamcolor tag.
  * @param message   Message (formatting rules).
- * @noreturn
  * 
  * On error/Errors:   If the author is not connected an error will be thrown.
  */
@@ -146,7 +142,6 @@ stock void MC_PrintToChatAllEx(int author, const char[] message, any ...) {
  * 
  * @param client	Client to send usermessage to
  * @param message	Message to send
- * @noreturn
  */
 stock void MC_SendMessage(int client, const char[] message, int author = 0) {
 	if(author == 0) {
@@ -193,7 +188,6 @@ stock void MC_SendMessage(int client, const char[] message, int author = 0) {
  * After printing the message, the client will no longer be skipped.
  * 
  * @param client   Client index
- * @noreturn
  */
 stock void MC_SkipNextClient(int client) {
 	if(client <= 0 || client > MaxClients) {
@@ -220,7 +214,6 @@ stock void MC_CheckTrie() {
  * @param author		Optional client index to use for {teamcolor} tags, or 0 for none
  * @param removeTags	Optional boolean value to determine whether we're replacing tags with colors, or just removing tags, used by MC_RemoveTags
  * @param maxlen		Optional value for max buffer length, used by MC_RemoveTags
- * @noreturn
  * 
  * On error/Errors:		If the client index passed for author is invalid or not in game.
  */
@@ -299,7 +292,6 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
  * @param maxlen		Max length of output buffer
  * @param start			Position to start at
  * @param numChars		Number of characters to return, or 0 for the end of the string
- * @noreturn
  */
 stock void CSubString(const char[] input, char[] output, int maxlen, int start, int numChars = 0) {
 	int i = 0;
@@ -317,7 +309,6 @@ stock void CSubString(const char[] input, char[] output, int maxlen, int start, 
  * Converts a string to lowercase
  * 
  * @param buffer		String to convert
- * @noreturn
  */
 stock void MC_StrToLower(char[] buffer) {
 	int len = strlen(buffer);
@@ -351,7 +342,6 @@ stock bool MC_AddColor(const char[] name, int color) {
  * 
  * @param message		Message to remove tags from
  * @param maxlen		Maximum buffer length
- * @noreturn
  */
 stock void MC_RemoveTags(char[] message, int maxlen) {
 	MC_ReplaceColorCodes(message, 0, true, maxlen);
@@ -362,13 +352,15 @@ stock void MC_RemoveTags(char[] message, int maxlen) {
  * 
  * @param client		Client to reply to
  * @param message		Message (formatting rules)
- * @noreturn
  */
 stock void MC_ReplyToCommand(int client, const char[] message, any ...) {
 	char buffer[MAX_BUFFER_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 3);
-	if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
+	if(client == 0) {
+		MC_RemoveTags(buffer, sizeof(buffer));
+		PrintToServer("%s", buffer);
+	} if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToConsole(client, "%s", buffer);
 	} else {
@@ -382,13 +374,15 @@ stock void MC_ReplyToCommand(int client, const char[] message, any ...) {
  * @param client		Client to reply to
  * @param author		Client to use for {teamcolor}
  * @param message		Message (formatting rules)
- * @noreturn
  */
 stock void MC_ReplyToCommandEx(int client, int author, const char[] message, any ...) {
 	char buffer[MAX_BUFFER_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 4);
-	if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
+	if(client == 0) {
+		MC_RemoveTags(buffer, sizeof(buffer));
+		PrintToServer("%s", buffer);
+	} if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToConsole(client, "%s", buffer);
 	} else {
@@ -409,7 +403,6 @@ stock void MC_ReplyToCommandEx(int client, int author, const char[] message, any
  * @param client		Client index doing the action, or 0 for server.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
  * @error
  */
 stock int MC_ShowActivity(int client, const char[] format, any ...)
@@ -525,7 +518,6 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
  * @param tags			Tag to display with.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
  * @error
  */
 stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, any ...)
@@ -641,7 +633,6 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
  * @param tags			Tag to prepend to the message.
  * @param format		Formatting rules.
  * @param ...			Variable number of format parameters.
- * @noreturn
  * @error
  */
 stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, any ...)

--- a/addons/sourcemod/scripting/include/multicolors/morecolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/morecolors.inc
@@ -245,11 +245,11 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
 	int value;
 	char tag[32], buff[32]; 
 	char[] output = new char[maxlen];
-	
+
 	strcopy(output, maxlen, buffer);
 	// Since the string's size is going to be changing, output will hold the replaced string and we'll search buffer
-	
-	Handle regex = CompileRegex("{[a-zA-Z0-9]+}");
+
+	Handle regex = CompileRegex("{[#a-zA-Z0-9]+}");
 	for(int i = 0; i < 1000; i++) { // The RegEx extension is quite flaky, so we have to loop here :/. This loop is supposed to be infinite and broken by return, but conditions have been added to be safe.
 		if(MatchRegex(regex, buffer[cursor]) < 1) {
 			CloseHandle(regex);
@@ -262,11 +262,25 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
 		strcopy(buff, sizeof(buff), tag);
 		ReplaceString(buff, sizeof(buff), "{", "");
 		ReplaceString(buff, sizeof(buff), "}", "");
-		
-		if(!GetTrieValue(MC_Trie, buff, value)) {
+
+		if (buff[0] == '#') {
+			if(strlen(buff) == 7) {
+				Format(buff, sizeof(buff), "\x07%s", buff[1]);
+			} else if (strlen(buff) == 9) {
+				Format(buff, sizeof(buff), "\x08%s", buff[1]);
+			} else {
+				continue;
+			}
+
+			if (removeTags) {
+				ReplaceString(output, maxlen, tag, "", false);
+			} else {
+				ReplaceString(output, maxlen, tag, buff, false);
+			}
+		} else if(!GetTrieValue(MC_Trie, buff, value)) {
 			continue;
 		}
-		
+
 		if(removeTags) {
 			ReplaceString(output, maxlen, tag, "", false);
 		} else {
@@ -402,14 +416,14 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 {
 	if (sm_show_activity == INVALID_HANDLE)
 		sm_show_activity = FindConVar("sm_show_activity");
-		
+
 	char tag[] = "[SM] ";
-	
+
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
 	int value = GetConVarInt(sm_show_activity);
 	ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
@@ -417,7 +431,7 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -425,13 +439,13 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 		{
 			sign = "PLAYER";
 		}
-		
+
 		/* Display the message to the client? */
 		if (replyto == SM_REPLY_TO_CONSOLE)
 		{
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 3);
-			
+
 			MC_RemoveTags(szBuffer, sizeof(szBuffer));
 			PrintToConsole(client, "%s%s\n", tag, szBuffer);
 			display_in_chat = true;
@@ -441,16 +455,16 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 3);
-		
+
 		MC_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -475,7 +489,7 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -494,12 +508,12 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -518,12 +532,12 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 {
 	if (sm_show_activity == INVALID_HANDLE)
 		sm_show_activity = FindConVar("sm_show_activity");
-		
+
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
 	int value = GetConVarInt(sm_show_activity);
 	ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
@@ -531,7 +545,7 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -539,13 +553,13 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 		{
 			sign = "PLAYER";
 		}
-		
+
 		/* Display the message to the client? */
 		if (replyto == SM_REPLY_TO_CONSOLE)
 		{
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 4);
-			
+
 			MC_RemoveTags(szBuffer, sizeof(szBuffer));
 			PrintToConsole(client, "%s%s\n", tag, szBuffer);
 			display_in_chat = true;
@@ -555,16 +569,16 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		MC_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -589,7 +603,7 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -608,12 +622,12 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -634,19 +648,19 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 {
 	if (sm_show_activity == INVALID_HANDLE)
 		sm_show_activity = FindConVar("sm_show_activity");
-	
+
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
 	int value = GetConVarInt(sm_show_activity);
 	// ReplySource replyto = GetCmdReplySource();
-	
+
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	if (client != 0)
 	{
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
-		
+
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
 		if (id == INVALID_ADMIN_ID
@@ -654,10 +668,10 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 		{
 			sign = "PLAYER";
 		}
-		
+
 		SetGlobalTransTarget(client);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		/* We don't display directly to the console because the chat text 
 		 * simply gets added to the console, so we don't want it to print 
 		 * twice.
@@ -668,16 +682,16 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 	{
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
-		
+
 		MC_RemoveTags(szBuffer, sizeof(szBuffer));
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
-	
+
 	if (!value)
 	{
 		return 1;
 	}
-	
+
 	MuCo_LoopClients(i)
 	{
 		if (i == 0
@@ -702,7 +716,7 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
@@ -721,13 +735,13 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 					newsign = name;
 				}
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
-				
+
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
 	}
-	
-	return 1;	
+
+	return 1;
 }
 
 /**

--- a/addons/sourcemod/scripting/multicolors_example.sp
+++ b/addons/sourcemod/scripting/multicolors_example.sp
@@ -16,6 +16,20 @@ public Plugin myinfo =
 public void OnPluginStart()
 {
 	RegConsoleCmd("sm_multicolors", Command_MultiColors);
+	RegConsoleCmd("sm_addprefix", Command_AddPrefix);
+	RegConsoleCmd("sm_clearprefix", Command_ClearPrefix);
+}
+
+public Action Command_AddPrefix(int client, int args)
+{
+	CSetPrefix("{#FF0000AA}[{#FFFF00}MultiColor{#FF0000AA}]");
+	CReplyToCommand(client, "You can use {#FFFFFF}sm_multicolors {default}now !");
+}
+
+public Action Command_ClearPrefix(int client, int args)
+{
+	CClearPrefix();
+	CReplyToCommand(client, "You can use {#FFFFFF}sm_multicolors {default}now !");
 }
 
 public Action Command_MultiColors(int client, int args)
@@ -31,22 +45,24 @@ public Action Command_MultiColors(int client, int args)
 	CShowActivity(client, "CShowActivity - {darkblue}%s - {darkred}%s", "Test", "Test");
 	CShowActivityEx(client, "[SM]", "CShowActivityEx - {darkblue}%s - {darkred}%s", "Test", "Test");
 	CShowActivity2(client, "[SM]", "CShowActivity2 - {darkblue}%s - {darkred}%s", "Test", "Test");
-	
+
 	char sName[MAX_NAME_LENGTH];
 	Format(sName, sizeof(sName), "{green}%N", client);
-	
+
 	CPrintToChat(client, "CPrintToChat - Name (Before CFormatColor): %s", sName);
 	PrintToChat(client, "PrintToChat - Name (Before CFormatColor): %s", sName);
 	CFormatColor(sName, MAX_NAME_LENGTH, client);
 	CPrintToChat(client, "CPrintToChat - Name (After CFormatColor): %s", sName);
 	PrintToChat(client, "PrintToChat - Name (After CFormatColor): %s", sName);
-	
+
 	Format(sName, sizeof(sName), "{green}%N", client);
-	
+
 	CPrintToChat(client, "Name (Before CFormatColor): %s", sName);
 	CRemoveTags(sName, MAX_NAME_LENGTH);
 	CPrintToChat(client, "Name (After CFormatColor): %s", sName);
-	
+
 	CPrintToChatObservers(client, "CPrintToChatObservers - {darkblue}%s - {darkred}%s", "Test", "Test");
 	CPrintToChatObserversEx(client, "CPrintToChatObserversEx - {darkblue}%s - {darkred}%s", "Test", "Test");
+
+	CPrintToServer("CPrintToServer - {darkblue}%s - {darkred}%s", "Test", "Test");
 }


### PR DESCRIPTION
I Added RGB and RGBA support like :

- `{#RRGGBB}`
- `{#RRGGBBAA}`

I also added a prefix logic :

By calling `CSetPrefix("{#FF0000}[my Prefix]")` you can add a prefix before all CPrint* function automatically, with the default color and a space between the prefix and the text. Ex :

This `"CSetPrefix("{#FF0000}[my Prefix]")"` become `"{#FF0000}[my Prefix]{default} "`

So the final message looks like :

`CPrintToChatAll("{red}somestuff")` show `[my Prefix] somestuff`

Finally I added `CPrintToServer` to print phrases which are normaly sent with functions like `CPrintToChat` (so with colors) but without any tags automaticaly.

Updated version to 2.1.0